### PR TITLE
updates to changes in X.509 API (renamings)

### DIFF
--- a/src/csr.ml
+++ b/src/csr.ml
@@ -9,7 +9,7 @@ let csr org cn length days certfile keyfile =
   Nocrypto_entropy_unix.initialize ();
   let privkey = `RSA (Nocrypto.Rsa.generate length) in
   let dn = [ `CN cn; `O org ] in
-  let csr = X509.CA.generate dn privkey in
+  let csr = X509.CA.request dn privkey in
   let csr_pem = X509.Encoding.Pem.Certificate_signing_request.to_pem_cstruct1 csr in
   let key_pem = X509.Encoding.Pem.Private_key.to_pem_cstruct1 privkey in
   match (write_pem certfile csr_pem, write_pem keyfile key_pem) with

--- a/src/selfsign.ml
+++ b/src/selfsign.ml
@@ -8,11 +8,11 @@ let selfsign common_name length days certfile keyfile =
   let start,expire = make_dates days in
   Nocrypto_entropy_unix.initialize ();
   let privkey = `RSA (Nocrypto.Rsa.generate length) in
-  let csr = X509.CA.generate issuer privkey in 
+  let csr = X509.CA.request issuer privkey in
   (* default is sha256; TODO probably should allow user to choose sha1 as well *)
   let cert = X509.CA.sign ~valid_from:start ~valid_until:expire
       csr privkey issuer in
-  let cert_pem = X509.Encoding.Pem.Cert.to_pem_cstruct1 cert in
+  let cert_pem = X509.Encoding.Pem.Certificate.to_pem_cstruct1 cert in
   let key_pem = X509.Encoding.Pem.Private_key.to_pem_cstruct1 privkey in
   match (write_pem certfile cert_pem, write_pem keyfile key_pem) with
   | Ok, Ok -> `Ok


### PR DESCRIPTION
I did some renaming in the X.509 library (generate -> request; Cert -> Certificate)... https://github.com/mirleft/ocaml-x509/pull/58 -- this PR adapts to those changes
