### PR TITLE
Multiple subject alternative names

### DIFF
--- a/src/selfsign.ml
+++ b/src/selfsign.ml
@@ -8,7 +8,7 @@ let selfsign common_name length days is_ca certfile keyfile =
   in
   let csr = X509.CA.request issuer (`RSA privkey) in
   let ent = if is_ca then `CA else `Server in
-  match Common.sign days (`RSA privkey) (`RSA (Nocrypto.Rsa.pub_of_priv privkey)) issuer csr None ent with
+  match Common.sign days (`RSA privkey) (`RSA (Nocrypto.Rsa.pub_of_priv privkey)) issuer csr [] ent with
   | Ok cert ->
      let cert_pem = X509.Encoding.Pem.Certificate.to_pem_cstruct1 cert in
      let key_pem = X509.Encoding.Pem.Private_key.to_pem_cstruct1 (`RSA privkey) in

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -1,6 +1,6 @@
 open Cmdliner
 
-let sign days is_ca client altname key cacert csr certfile altnames =
+let sign days is_ca client key cacert csr certfile altnames =
   match Common.(read_pem key, read_pem cacert, read_pem csr) with
   | Common.Ok key, Common.Ok cacert, Common.Ok csr ->
      let key = X509.Encoding.Pem.Private_key.of_pem_cstruct1 key
@@ -13,13 +13,13 @@ let sign days is_ca client altname key cacert csr certfile altnames =
        | false, false -> `Server
      in
      let names =
-       if altname then
+       match altnames with
+       | [] -> []
+       | altnames ->
          let info = X509.CA.info csr in
          match List.filter (function `CN _ -> true | _ -> false) info.X509.CA.subject with
          | [ `CN x ] -> x :: altnames
          | _ -> altnames
-       else
-         []
      in
      let issuer = X509.subject cacert in
      let pubkey = X509.public_key cacert in
@@ -38,13 +38,9 @@ let client =
   let doc = "Add ExtendedKeyUsage extension to be ClientAuth (ServerAuth if absent and not CA)" in
   Arg.(value & flag & info ["client"] ~doc)
 
-let altname =
-  let doc = "Add SubjectAlternativeName extension where DNSName is CommonName of the subject" in
-  Arg.(value & flag & info ["altname"] ~doc)
-
 let altnames =
   let doc = "Add DNSName to SubjectAlternativeName" in
-  Arg.(value & pos_all string [] & info [] ~docv:"ALTNAME" ~doc)
+  Arg.(value & opt_all string [] & info ["altname"] ~doc)
 
 let keyin =
   let doc = "Filename of the private key." in
@@ -70,7 +66,7 @@ let is_ca =
   let doc = "Sign a CA cert (and include appropriate extensions)." in
   Arg.(value & flag & info ["C"; "ca"] ~doc)
 
-let sign_t = Term.(pure sign $ days $ is_ca $ client $ altname $ keyin $ cain $ csrin $ certfile $ altnames)
+let sign_t = Term.(pure sign $ days $ is_ca $ client $ keyin $ cain $ csrin $ certfile $ altnames)
 
 let info =
   let doc = "sign a certificate" in

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -16,11 +16,11 @@ let sign days is_ca client altname key cacert csr certfile altnames =
        if altname then
          let info = X509.CA.info csr in
          match List.filter (function `CN _ -> true | _ -> false) info.X509.CA.subject with
-         | [ `CN x ] -> [ x ]
-         | _ -> []
+         | [ `CN x ] -> x :: altnames
+         | _ -> altnames
        else
          []
-     in let names = names @ altnames in
+     in
      let issuer = X509.subject cacert in
      let pubkey = X509.public_key cacert in
      Nocrypto_entropy_unix.initialize ();


### PR DESCRIPTION
I have changed `sign` such that the remainder of arguments are interpreted as additional subject alternative names. It's handy if you want one certifcate that's valid for e.g. both reyn.ir and www.reyn.ir.

The changes in the code are not too big, but perhaps not too elegant either.
