### PR TITLE
Use subcommands

### DIFF
--- a/pkg/pkg.ml
+++ b/pkg/pkg.ml
@@ -6,7 +6,5 @@ open Topkg
 let () =
   Pkg.describe "certify" @@ fun _c ->
   Ok [
-    Pkg.bin "src/csr";
-    Pkg.bin "src/selfsign";
-    Pkg.bin "src/sign";
+    Pkg.bin "src/certify";
   ]

--- a/src/certify.ml
+++ b/src/certify.ml
@@ -1,0 +1,17 @@
+open Cmdliner
+
+let default =
+  Term.(ret (const (`Help (`Auto, None))))
+and default_info =
+  let doc = "Certificate signing tools" in
+  let man = [ `S "BUGS";
+              `P "Submit bugs at https://github.com/yomimono/ocaml-certify";] in
+  Term.info "certify" ~doc ~man
+
+let () =
+  Term.exit @@
+  Term.eval_choice
+    (default, default_info)
+    [(Sign.sign_t, Sign.sign_info);
+     (Selfsign.selfsign_t, Selfsign.selfsign_info);
+     (Csr.csr_t, Csr.csr_info)]

--- a/src/csr.ml
+++ b/src/csr.ml
@@ -27,5 +27,3 @@ let csr_info =
   let man = [ `S "BUGS";
               `P "Submit bugs at https://github.com/yomimono/ocaml-certify";] in
   Term.info "csr" ~doc ~man
-
-let () = Term.(exit @@ eval (csr_t, csr_info))

--- a/src/selfsign.ml
+++ b/src/selfsign.ml
@@ -30,5 +30,3 @@ let selfsign_info =
   let man = [ `S "BUGS";
               `P "Submit bugs at https://github.com/yomimono/ocaml-certify";] in
   Term.info "selfsign" ~doc ~man
-
-let () = Term.(exit @@ eval (selfsign_t, selfsign_info))

--- a/src/sign.ml
+++ b/src/sign.ml
@@ -74,5 +74,3 @@ let sign_info =
   let man = [ `S "BUGS";
               `P "Submit bugs at https://github.com/yomimono/ocaml-certify";] in
   Term.info "sign" ~doc ~man
-
-let () = Term.(exit @@ eval (sign_t, sign_info))


### PR DESCRIPTION
This commit bundles the three binaries under one called `certify` using subcommands with a default action of printing the help page. This reduces the number of potential name conflicts as well as adds some affordability when installing certify from opam -- the binary is the name of the package :-)

This is a breaking change!