### PR TITLE
use Term.term_result and unify to (_, [ Msg of string ]) result, remove custom result type

### DIFF
--- a/src/csr.ml
+++ b/src/csr.ml
@@ -17,10 +17,10 @@ let csr org cn length certfile keyfile =
   let csr_pem = X509.Encoding.Pem.Certificate_signing_request.to_pem_cstruct1 csr in
   let key_pem = X509.Encoding.Pem.Private_key.to_pem_cstruct1 privkey in
   match (write_pem certfile csr_pem, write_pem keyfile key_pem) with
-  | Ok (), Ok () -> `Ok
-  | Error str, _ | _, Error str -> Printf.eprintf "%s\n" str; `Error
+  | Ok (), Ok () -> Ok ()
+  | Error str, _ | _, Error str -> Error str
 
-let csr_t = Term.(pure csr $ org $ common_name $ length $ certfile $ keyfile )
+let csr_t = Term.(term_result (pure csr $ org $ common_name $ length $ certfile $ keyfile))
 
 let csr_info =
   let doc = "generate a certificate-signing request" in

--- a/src/selfsign.ml
+++ b/src/selfsign.ml
@@ -13,10 +13,10 @@ let selfsign common_name length days is_ca certfile keyfile =
      let cert_pem = X509.Encoding.Pem.Certificate.to_pem_cstruct1 cert in
      let key_pem = X509.Encoding.Pem.Private_key.to_pem_cstruct1 (`RSA privkey) in
      (match write_pem certfile cert_pem, write_pem keyfile key_pem with
-      | Ok (), Ok () -> `Ok
+      | Ok (), Ok () -> Ok ()
       | Error str, _
-      | _, Error str -> Printf.eprintf "%s\n" str; `Error)
-  | Error str -> Printf.eprintf "%s\n" str; `Error
+      | _, Error str -> Error str)
+  | Error str -> Error str
 
 let certfile =
   let doc = "Filename to which to save the completed certificate." in


### PR DESCRIPTION
further improvements could be to use the Rresult combinators... I did this primarily for the soon-to-be-changed X.509 API (see https://github.com/mirleft/ocaml-x509/pull/113), which will use the result type (and `` `Msg of string ``).

let me know what you think of this PR