### PR TITLE
Allow to execute the tests in opam (the sandbox forbids to use /tmp by default)

### DIFF
--- a/test/test.sh
+++ b/test/test.sh
@@ -4,8 +4,8 @@ set -e
 
 [ "${EXTENSION}" = "" ] #&& EXTENSION=.native
 [ "${BINDIR}" = "" ] && BINDIR="_build/install/default/bin"
-[ "${CERTDIR}" = "" ] && CERTDIR="/tmp/$$"
-[ "${KEYDIR}" = "" ] && KEYDIR="/tmp/$$"
+[ "${CERTDIR}" = "" ] && CERTDIR=$(mktemp -d)
+[ "${KEYDIR}" = "" ] && KEYDIR=$(mktemp -d)
 [ "${OPENSSL}" = "" ] && OPENSSL="openssl"
 [ "${KEY_LENGTH}" = "" ] && KEY_LENGTH=4096
 


### PR DESCRIPTION
The standard `$TMPDIR` variable should be used instead and mktemp uses it