### PR TITLE
Add missing dependencies

### DIFF
--- a/certify.opam
+++ b/certify.opam
@@ -24,6 +24,7 @@ depends: [
   "ocaml" {>= "4.07.0"}
   "cmdliner" {>= "1.0.0"}
   "conf-openssl" {with-test}
+  "rresult"
 ]
 description: """
 `certify` is a small selection of useful utilities for manipulating X509 certificates and public keys.  It uses the mirleft organization's x509, tls, and nocrypto libraries.

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name certify_cli)
   (modules common)
   (wrapped false)
-  (libraries cmdliner cstruct x509 mirage-crypto-pk ptime ptime.clock.os))
+  (libraries cmdliner cstruct x509 mirage-crypto-pk ptime ptime.clock.os rresult))
 
 (executable
   (name certify)

--- a/src/dune
+++ b/src/dune
@@ -2,7 +2,7 @@
   (name certify_cli)
   (modules common)
   (wrapped false)
-  (libraries cmdliner cstruct x509 mirage-crypto-pk ptime ptime.clock.os rresult))
+  (libraries cmdliner cstruct x509 mirage-crypto-pk ptime ptime.clock.os rresult unix))
 
 (executable
   (name certify)


### PR DESCRIPTION
Adds a missing implicit dependency on rresult; silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.